### PR TITLE
Added ability to view arbitrary path or URL.

### DIFF
--- a/resources/gorilla-repl-client/js-viewer/main-viewer.js
+++ b/resources/gorilla-repl-client/js-viewer/main-viewer.js
@@ -28,6 +28,16 @@ var app = function () {
     };
 
     self.start = function (worksheetData, sourceURL, worksheetName, source) {
+        var host = "";
+        switch(source.toLowerCase()) {
+            case "bitbucket":
+                host = "BitBucket";
+                break;
+            case "github":
+            case "gist":
+                host = "Github";
+                break;
+        }
 
         var ws = worksheet();
         ws.segments = ko.observableArray(worksheetParser.parse(worksheetData));
@@ -35,7 +45,7 @@ var app = function () {
         self.sourceURL(sourceURL);
         self.filename(worksheetName);
         self.source(source);
-        self.host((source.toLowerCase() === "bitbucket") ? "Bitbucket" : "GitHub");
+        self.host(host);
 
         // wire up the UI
         ko.applyBindings(self, document.getElementById("document"));

--- a/resources/gorilla-repl-client/js-viewer/main-viewer.js
+++ b/resources/gorilla-repl-client/js-viewer/main-viewer.js
@@ -88,5 +88,10 @@ $(function () {
             $.get('/test.clj').success(function (data) {
                 viewer.start(data, "http://gorilla-repl.org/", "test.clj", source);
             });
+        case "file":
+            var path = getParameterByName("path");
+            $.get(path).success(function(data) {
+                viewer.start(data, path, path, source);
+            });
     }
 });

--- a/resources/gorilla-repl-client/view.html
+++ b/resources/gorilla-repl-client/view.html
@@ -50,7 +50,7 @@
 <div class="header">
     <div class="header-left">Made with <a href="http://clojure.org" target="_blank">Clojure</a> and
         <a href="http://gorilla-repl.org" target="_blank">Gorilla REPL</a></div>
-    <div class="header-right">
+    <div class="header-right" data-bind="visible: host">
         <a href="#" data-bind="click: showCopyBox">View this worksheet on <span data-bind="text: host"></span></a>
     </div>
 </div>


### PR DESCRIPTION
This pull request adds a "file" source to the worksheet viewer that allows a worksheet at any URL to be displayed.

The motivation for this change was the ability to self-host worksheets without needing to upload them to Github or Bitbucket.
